### PR TITLE
feat(validation): display attribute-option-combos

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-11-01T13:41:47.279Z\n"
-"PO-Revision-Date: 2019-11-01T13:41:47.279Z\n"
+"POT-Creation-Date: 2020-11-11T12:05:33.779Z\n"
+"PO-Revision-Date: 2020-11-11T12:05:33.779Z\n"
 
 msgid "Data Quality"
 msgstr ""
@@ -114,6 +114,9 @@ msgid "Persist new results"
 msgstr ""
 
 msgid "validate"
+msgstr ""
+
+msgid "Attr. Opt. Combo"
 msgstr ""
 
 msgid "Importance"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-11-11T12:05:33.779Z\n"
-"PO-Revision-Date: 2020-11-11T12:05:33.779Z\n"
+"POT-Creation-Date: 2020-11-12T12:20:04.534Z\n"
+"PO-Revision-Date: 2020-11-12T12:20:04.534Z\n"
 
 msgid "Data Quality"
 msgstr ""
@@ -114,6 +114,9 @@ msgid "Persist new results"
 msgstr ""
 
 msgid "validate"
+msgstr ""
+
+msgid "Attribute Option Combination"
 msgstr ""
 
 msgid "Attr. Opt. Combo"

--- a/src/components/table/TableCellContent.js
+++ b/src/components/table/TableCellContent.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import styles from './TableCellContent.module.css'
 import cx from 'classnames'
 
-const key = size => styles[`tableCellContent-${size}`]
-
 const TableCellContent = props => (
     <div
         className={cx(styles.tableCellContent, props.className, {

--- a/src/components/table/TableCellContent.js
+++ b/src/components/table/TableCellContent.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styles from './TableCellContent.module.css'
+import cx from 'classnames'
+
+const key = size => styles[`tableCellContent-${size}`]
+
+const TableCellContent = props => (
+    <div
+        className={cx(styles.tableCellContent, props.className, {
+            [styles[`tableCellContent-${props.size}`]]: props.size,
+        })}
+    >
+        {props.children}
+    </div>
+)
+
+TableCellContent.propTypes = {
+    size: PropTypes.oneOf(['narrow', 'medium', 'wide']),
+}
+
+export default TableCellContent

--- a/src/components/table/TableCellContent.module.css
+++ b/src/components/table/TableCellContent.module.css
@@ -3,7 +3,9 @@
     margin: 5px 0 5px 0;
     display: -webkit-box;
     -webkit-line-clamp: 3;
+    /* autoprefixer: off */
     -webkit-box-orient: vertical;
+    /* autoprefixer: on */
     overflow: hidden;
     white-space: pre-wrap;
     text-overflow: ellipsis;

--- a/src/components/table/TableCellContent.module.css
+++ b/src/components/table/TableCellContent.module.css
@@ -1,0 +1,22 @@
+.tableCellContent {
+    max-height: 64px;
+    margin: 5px 0 5px 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    white-space: pre-wrap;
+    text-overflow: ellipsis;
+}
+
+.tableCellContent-narrow {
+    max-width: 50px;
+}
+
+.tableCellContent-medium {
+    max-width: 150px;
+}
+
+.tableCellContent-wide {
+    max-width: 250px;
+}

--- a/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
+++ b/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
@@ -75,6 +75,7 @@ class ValidationRulesAnalysis extends Page {
     static convertElementFromApiResponse = e => ({
         key: ValidationRulesAnalysis.generateElementKey(e),
         validationRuleId: e.validationRuleId,
+        attributeOptionCombo: e.attributeOptionComboDisplayName,
         organisation: e.organisationUnitDisplayName,
         organisationUnitId: e.organisationUnitId,
         period: e.periodDisplayName,

--- a/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
+++ b/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
@@ -70,12 +70,15 @@ class ValidationRulesAnalysis extends Page {
     }
 
     static generateElementKey = e =>
-        `${e.validationRuleId}-${e.periodId}-${e.organisationUnitId}`
+        `${e.validationRuleId}-${e.periodId}-${e.organisationUnitId}-${
+            e.attributeOptionComboId
+        }`
 
     static convertElementFromApiResponse = e => ({
         key: ValidationRulesAnalysis.generateElementKey(e),
         validationRuleId: e.validationRuleId,
         attributeOptionCombo: e.attributeOptionComboDisplayName,
+        attributeOptionComboId: e.attributeOptionComboId,
         organisation: e.organisationUnitDisplayName,
         organisationUnitId: e.organisationUnitId,
         period: e.periodDisplayName,

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
@@ -26,7 +26,7 @@ class ValidationRulesAnalysisTable extends PureComponent {
         const elements = this.props.elements
 
         const shouldDisplayAttributeOptionCombo = elements.some(
-            e => e.attributeOptionCombo !== 'default'
+            e => e.attributeOptionCombo && e.attributeOptionCombo !== 'default'
         )
 
         // Table Rows
@@ -56,7 +56,7 @@ class ValidationRulesAnalysisTable extends PureComponent {
                     <FormattedNumber value={element.leftValue} />
                 </TableRowColumn>
                 <TableRowColumn
-                    className={cssPageStyles.right}
+                    className={classNames(cssPageStyles.right, styles.smallTd)}
                     title={element.operator}
                 >
                     <span className={styles.operator}>{element.operator}</span>
@@ -129,7 +129,10 @@ class ValidationRulesAnalysisTable extends PureComponent {
                                 {i18n.t('Value')}
                             </TableHeaderColumn>
                             <TableHeaderColumn
-                                className={cssPageStyles.right}
+                                className={classNames(
+                                    cssPageStyles.right,
+                                    styles.smallTd
+                                )}
                                 title={i18n.t('Operator')}
                             >
                                 {i18n.t('Operator')}

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
@@ -85,7 +85,7 @@ class ValidationRulesAnalysisTable extends PureComponent {
                             </TableHeaderColumn>
                             {shouldDisplayAttributeOptionCombo && (
                                 <TableHeaderColumn>
-                                    {i18n.t('Attribute Option Combination')}
+                                    {i18n.t('Attr. Opt. Combo')}
                                 </TableHeaderColumn>
                             )}
                             <TableHeaderColumn>

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
@@ -34,7 +34,7 @@ class ValidationRulesAnalysisTable extends PureComponent {
         const rows = elements.map(element => (
             <TableRow key={element.key}>
                 <TableRowColumn title={element.organisation}>
-                    {element.organisation}
+                    <TableCellContent>{element.organisation}</TableCellContent>
                 </TableRowColumn>
                 {shouldDisplayAttributeOptionCombo && (
                     <TableRowColumn title={element.attributeOptionCombo}>

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
@@ -32,22 +32,39 @@ class ValidationRulesAnalysisTable extends PureComponent {
         // Table Rows
         const rows = elements.map(element => (
             <TableRow key={element.key}>
-                <TableRowColumn>{element.organisation}</TableRowColumn>
+                <TableRowColumn title={element.organisation}>
+                    {element.organisation}
+                </TableRowColumn>
                 {shouldDisplayAttributeOptionCombo && (
-                    <TableRowColumn>
+                    <TableRowColumn title={element.attributeOptionCombo}>
                         {element.attributeOptionCombo}
                     </TableRowColumn>
                 )}
-                <TableRowColumn>{element.period}</TableRowColumn>
-                <TableRowColumn>{element.importance}</TableRowColumn>
-                <TableRowColumn>{element.validationRule}</TableRowColumn>
-                <TableRowColumn className={cssPageStyles.right}>
+                <TableRowColumn title={element.period}>
+                    {element.period}
+                </TableRowColumn>
+                <TableRowColumn title={element.importance}>
+                    {element.importance}
+                </TableRowColumn>
+                <TableRowColumn title={element.validationRule}>
+                    {element.validationRule}
+                </TableRowColumn>
+                <TableRowColumn
+                    className={cssPageStyles.right}
+                    title={element.leftValue}
+                >
                     <FormattedNumber value={element.leftValue} />
                 </TableRowColumn>
-                <TableRowColumn className={cssPageStyles.right}>
+                <TableRowColumn
+                    className={cssPageStyles.right}
+                    title={element.operator}
+                >
                     <span className={styles.operator}>{element.operator}</span>
                 </TableRowColumn>
-                <TableRowColumn className={cssPageStyles.right}>
+                <TableRowColumn
+                    className={cssPageStyles.right}
+                    title={element.rightValue}
+                >
                     <FormattedNumber value={element.rightValue} />
                 </TableRowColumn>
                 <TableRowColumn className={cssPageStyles.center}>
@@ -80,33 +97,53 @@ class ValidationRulesAnalysisTable extends PureComponent {
                         enableSelectAll={false}
                     >
                         <TableRow>
-                            <TableHeaderColumn>
+                            <TableHeaderColumn
+                                title={i18n.t('Organisation Unit')}
+                            >
                                 {i18n.t('Organisation Unit')}
                             </TableHeaderColumn>
                             {shouldDisplayAttributeOptionCombo && (
-                                <TableHeaderColumn>
+                                <TableHeaderColumn
+                                    title={i18n.t(
+                                        'Attribute Option Combination'
+                                    )}
+                                >
                                     {i18n.t('Attr. Opt. Combo')}
                                 </TableHeaderColumn>
                             )}
-                            <TableHeaderColumn>
+                            <TableHeaderColumn title={i18n.t('Period')}>
                                 {i18n.t('Period')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn>
+                            <TableHeaderColumn title={i18n.t('Importance')}>
                                 {i18n.t('Importance')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn>
+                            <TableHeaderColumn
+                                title={i18n.t('Validation Rule')}
+                            >
                                 {i18n.t('Validation Rule')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn className={cssPageStyles.right}>
+                            <TableHeaderColumn
+                                className={cssPageStyles.right}
+                                title={i18n.t('Value')}
+                            >
                                 {i18n.t('Value')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn className={cssPageStyles.right}>
+                            <TableHeaderColumn
+                                className={cssPageStyles.right}
+                                title={i18n.t('Operator')}
+                            >
                                 {i18n.t('Operator')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn className={cssPageStyles.right}>
+                            <TableHeaderColumn
+                                className={cssPageStyles.right}
+                                title={i18n.t('Value')}
+                            >
                                 {i18n.t('Value')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn className={cssPageStyles.center}>
+                            <TableHeaderColumn
+                                className={cssPageStyles.center}
+                                title={i18n.t('Details')}
+                            >
                                 {i18n.t('Details')}
                             </TableHeaderColumn>
                         </TableRow>

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
@@ -16,6 +16,7 @@ import styles from './ValidationRulesAnalysisTable.module.css'
 import i18n from '../../../locales'
 import ValidationRulesDetails from '../validation-rules-details/ValidationRulesDetails'
 import { apiConf } from '../../../server.conf'
+import TableCellContent from '../../../components/table/TableCellContent'
 
 class ValidationRulesAnalysisTable extends PureComponent {
     static propTypes = {
@@ -37,42 +38,45 @@ class ValidationRulesAnalysisTable extends PureComponent {
                 </TableRowColumn>
                 {shouldDisplayAttributeOptionCombo && (
                     <TableRowColumn title={element.attributeOptionCombo}>
-                        {element.attributeOptionCombo}
+                        <TableCellContent size="wide">
+                            {element.attributeOptionCombo}
+                        </TableCellContent>
                     </TableRowColumn>
                 )}
                 <TableRowColumn title={element.period}>
-                    {element.period}
+                    <TableCellContent>{element.period}</TableCellContent>
                 </TableRowColumn>
                 <TableRowColumn title={element.importance}>
-                    {element.importance}
+                    <TableCellContent>{element.importance}</TableCellContent>
                 </TableRowColumn>
                 <TableRowColumn title={element.validationRule}>
-                    {element.validationRule}
+                    <TableCellContent size={'medium'}>
+                        {element.validationRule}
+                    </TableCellContent>
                 </TableRowColumn>
-                <TableRowColumn
-                    className={cssPageStyles.right}
-                    title={element.leftValue}
-                >
-                    <FormattedNumber value={element.leftValue} />
+                <TableRowColumn title={element.leftValue}>
+                    <TableCellContent>
+                        <FormattedNumber value={element.leftValue} />
+                    </TableCellContent>
                 </TableRowColumn>
-                <TableRowColumn
-                    className={classNames(cssPageStyles.right, styles.smallTd)}
-                    title={element.operator}
-                >
-                    <span className={styles.operator}>{element.operator}</span>
+                <TableRowColumn title={element.operator}>
+                    <TableCellContent className={styles.operator}>
+                        {element.operator}
+                    </TableCellContent>
                 </TableRowColumn>
-                <TableRowColumn
-                    className={cssPageStyles.right}
-                    title={element.rightValue}
-                >
-                    <FormattedNumber value={element.rightValue} />
+                <TableRowColumn title={element.rightValue}>
+                    <TableCellContent>
+                        <FormattedNumber value={element.rightValue} />
+                    </TableCellContent>
                 </TableRowColumn>
-                <TableRowColumn className={cssPageStyles.center}>
-                    <ValidationRulesDetails
-                        validationRuleId={element.validationRuleId}
-                        periodId={element.periodId}
-                        organisationUnitId={element.organisationUnitId}
-                    />
+                <TableRowColumn>
+                    <TableCellContent>
+                        <ValidationRulesDetails
+                            validationRuleId={element.validationRuleId}
+                            periodId={element.periodId}
+                            organisationUnitId={element.organisationUnitId}
+                        />
+                    </TableCellContent>
                 </TableRowColumn>
             </TableRow>
         ))
@@ -90,6 +94,8 @@ class ValidationRulesAnalysisTable extends PureComponent {
                         cssPageStyles.appTable,
                         styles.validationTable
                     )}
+                    fixedHeader={false}
+                    bodyStyle={{ overflowX: 'auto' }}
                 >
                     <TableHeader
                         displaySelectAll={false}
@@ -122,31 +128,16 @@ class ValidationRulesAnalysisTable extends PureComponent {
                             >
                                 {i18n.t('Validation Rule')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn
-                                className={cssPageStyles.right}
-                                title={i18n.t('Value')}
-                            >
+                            <TableHeaderColumn title={i18n.t('Value')}>
                                 {i18n.t('Value')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn
-                                className={classNames(
-                                    cssPageStyles.right,
-                                    styles.smallTd
-                                )}
-                                title={i18n.t('Operator')}
-                            >
+                            <TableHeaderColumn title={i18n.t('Operator')}>
                                 {i18n.t('Operator')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn
-                                className={cssPageStyles.right}
-                                title={i18n.t('Value')}
-                            >
+                            <TableHeaderColumn title={i18n.t('Value')}>
                                 {i18n.t('Value')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn
-                                className={cssPageStyles.center}
-                                title={i18n.t('Details')}
-                            >
+                            <TableHeaderColumn title={i18n.t('Details')}>
                                 {i18n.t('Details')}
                             </TableHeaderColumn>
                         </TableRow>

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
@@ -25,10 +25,19 @@ class ValidationRulesAnalysisTable extends PureComponent {
     render() {
         const elements = this.props.elements
 
+        const shouldDisplayAttributeOptionCombo = elements.some(
+            e => e.attributeOptionCombo !== 'default'
+        )
+
         // Table Rows
         const rows = elements.map(element => (
             <TableRow key={element.key}>
                 <TableRowColumn>{element.organisation}</TableRowColumn>
+                {shouldDisplayAttributeOptionCombo && (
+                    <TableRowColumn>
+                        {element.attributeOptionCombo}
+                    </TableRowColumn>
+                )}
                 <TableRowColumn>{element.period}</TableRowColumn>
                 <TableRowColumn>{element.importance}</TableRowColumn>
                 <TableRowColumn>{element.validationRule}</TableRowColumn>
@@ -74,6 +83,11 @@ class ValidationRulesAnalysisTable extends PureComponent {
                             <TableHeaderColumn>
                                 {i18n.t('Organisation Unit')}
                             </TableHeaderColumn>
+                            {shouldDisplayAttributeOptionCombo && (
+                                <TableHeaderColumn>
+                                    {i18n.t('Attribute Option Combination')}
+                                </TableHeaderColumn>
+                            )}
                             <TableHeaderColumn>
                                 {i18n.t('Period')}
                             </TableHeaderColumn>

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.js
@@ -75,6 +75,9 @@ class ValidationRulesAnalysisTable extends PureComponent {
                             validationRuleId={element.validationRuleId}
                             periodId={element.periodId}
                             organisationUnitId={element.organisationUnitId}
+                            attributeOptionComboId={
+                                element.attributeOptionComboId
+                            }
                         />
                     </TableCellContent>
                 </TableRowColumn>

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.module.css
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.module.css
@@ -1,12 +1,8 @@
-.validationTable
-    td:nth-child(3),
-    td:nth-child(5),
-    td:nth-child(6),
-    td:nth-child(7)
-    {
-        overflow: visible !important;
-    }
+.validationTable {
+    table-layout: auto !important;
+}
 
 .operator {
     font-size: 16px !important;
+    text-align: center;
 }

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.test.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.test.js
@@ -25,6 +25,8 @@ const rulesElements = [
         validationRule: 'Malaria outbrek',
         validationRuleId: 'kgh54Xb9LSE',
         organisationUnitId: 'OrgUnitkgh54Xb9LSE',
+        attributeOptionCombo: 'default',
+        attributeOptionComboId: 'HllvX50cXC0',
     },
     {
         key: 'ktwo',
@@ -38,6 +40,8 @@ const rulesElements = [
         validationRule: 'Malaria outbrek',
         validationRuleId: 'kgh54Xb9LSS',
         organisationUnitId: 'OrgUnitkgh54Xb9LSS',
+        attributeOptionCombo: 'default',
+        attributeOptionComboId: 'HllvX50cXC0',
     },
 ]
 
@@ -122,12 +126,13 @@ describe('Test <ValidationRulesAnalysisTable /> rendering:', () => {
         expect(wrapper.find(DownloadAs).length).toBe(2)
     })
 
-    it('Should render attribute option combo column if not default', () => {
+    it('Should render attribute option combo column if attribute opt. combo other than default is present', () => {
         expect(
             withAttrOptCombos()
                 .find(TableRow)
-                .at(1)
-                .find(TableRowColumn).length
-        ).toBe(9) // First row after header
+                .at(0)
+                .childAt(1)
+                .prop('title')
+        ).toBe('Attribute Option Combination')
     })
 })

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.test.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.test.js
@@ -25,7 +25,6 @@ const rulesElements = [
         validationRule: 'Malaria outbrek',
         validationRuleId: 'kgh54Xb9LSE',
         organisationUnitId: 'OrgUnitkgh54Xb9LSE',
-        //attributeOptionCombo: 'default'
     },
     {
         key: 'ktwo',
@@ -39,7 +38,6 @@ const rulesElements = [
         validationRule: 'Malaria outbrek',
         validationRuleId: 'kgh54Xb9LSS',
         organisationUnitId: 'OrgUnitkgh54Xb9LSS',
-        //attributeOptionCombo: 'default'
     },
 ]
 

--- a/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.test.js
+++ b/src/pages/validation-rules-analysis/validation-rules-analysis-table/ValidationRulesAnalysisTable.test.js
@@ -25,6 +25,7 @@ const rulesElements = [
         validationRule: 'Malaria outbrek',
         validationRuleId: 'kgh54Xb9LSE',
         organisationUnitId: 'OrgUnitkgh54Xb9LSE',
+        //attributeOptionCombo: 'default'
     },
     {
         key: 'ktwo',
@@ -38,6 +39,41 @@ const rulesElements = [
         validationRule: 'Malaria outbrek',
         validationRuleId: 'kgh54Xb9LSS',
         organisationUnitId: 'OrgUnitkgh54Xb9LSS',
+        //attributeOptionCombo: 'default'
+    },
+]
+
+const rulesElementsWithAttrOptCombos = [
+    {
+        attributeOptionCombo: 'default',
+        attributeOptionComboId: 'HllvX50cXC0',
+        importance: 'MEDIUM',
+        key: 'SxwKDzs5Rlb-202010-rZxk3S0qN63-HllvX50cXC0',
+        leftValue: 11,
+        operator: '==',
+        organisation: 'Bo Govt. Hosp.',
+        organisationUnitId: 'rZxk3S0qN63',
+        period: 'October 2020',
+        periodId: '202010',
+        rightValue: 5,
+        validationRule: 'ART stage 1 = stage 2',
+        validationRuleId: 'SxwKDzs5Rlb',
+    },
+    {
+        key: 'SxwKDzs5Rlb-202010-DiszpKrYNg8-vp1qSLVMSc3',
+        validationRuleId: 'SxwKDzs5Rlb',
+        attributeOptionCombo:
+            'African Medical and Research Foundation, Provide access to basic education',
+        attributeOptionComboId: 'vp1qSLVMSc3',
+        organisation: 'Ngelehun CHC',
+        organisationUnitId: 'DiszpKrYNg8',
+        period: 'October 2020',
+        periodId: '202010',
+        importance: 'MEDIUM',
+        validationRule: 'ART stage 1 = stage 2',
+        leftValue: 23,
+        operator: '==',
+        rightValue: 0,
     },
 ]
 
@@ -47,6 +83,16 @@ const ownShallow = () => {
     })
 }
 
+const withAttrOptCombos = () => {
+    return shallow(
+        <ValidationRulesAnalysisTable
+            elements={rulesElementsWithAttrOptCombos}
+        />,
+        {
+            disableLifecycleMethods: true,
+        }
+    )
+}
 describe('Test <ValidationRulesAnalysisTable /> rendering:', () => {
     let wrapper
     beforeEach(() => {
@@ -76,5 +122,14 @@ describe('Test <ValidationRulesAnalysisTable /> rendering:', () => {
 
     it('Render "DownloadAs" component.', () => {
         expect(wrapper.find(DownloadAs).length).toBe(2)
+    })
+
+    it('Should render attribute option combo column if not default', () => {
+        expect(
+            withAttrOptCombos()
+                .find(TableRow)
+                .at(1)
+                .find(TableRowColumn).length
+        ).toBe(9) // First row after header
     })
 })

--- a/src/pages/validation-rules-analysis/validation-rules-details/ValidationRulesDetails.js
+++ b/src/pages/validation-rules-analysis/validation-rules-details/ValidationRulesDetails.js
@@ -18,6 +18,7 @@ class ValidationRulesDetails extends Page {
         validationRuleId: PropTypes.string.isRequired,
         periodId: PropTypes.string.isRequired,
         organisationUnitId: PropTypes.string.isRequired,
+        attributeOptionComboId: PropTypes.string.isRequired,
     }
 
     constructor() {
@@ -64,7 +65,8 @@ class ValidationRulesDetails extends Page {
                 `${apiConf.endpoints.validationRulesExpression}` +
                 `?validationRuleId=${this.props.validationRuleId}` +
                 `&periodId=${this.props.periodId}` +
-                `&organisationUnitId=${this.props.organisationUnitId}`
+                `&organisationUnitId=${this.props.organisationUnitId}` +
+                `&attributeOptionComboId=${this.props.attributeOptionComboId}`
             this.context.updateAppState({
                 pageState: {
                     loading: true,

--- a/src/pages/validation-rules-analysis/validation-rules-details/ValidationRulesDetails.test.js
+++ b/src/pages/validation-rules-analysis/validation-rules-details/ValidationRulesDetails.test.js
@@ -90,6 +90,7 @@ const ownShallow = () => {
             organisationUnitId={'organisationUnitId'}
             periodId={'periodId'}
             validationRuleId={'validationRuleId'}
+            attributeOptionComboId={'HllvX50qcXC0'}
         />,
         {
             context: {


### PR DESCRIPTION
See [DHIS2-8877](https://jira.dhis2.org/browse/DHIS2-8877)

I've also tried to improve the table-layout. It was not ideal before, as certain columns like "operator" used more space than necessary. 
I've changed the table to use `table-layout: auto` which should improve that. In addition, I've introduced `TableCellContent` which is used to wrapped the content in a cell. The primary need for this is to have multiline ellipsis on longer text.