### PR TITLE
feat(orgunit-select): only show user-assigned orgunits

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-11-12T12:20:04.534Z\n"
-"PO-Revision-Date: 2020-11-12T12:20:04.534Z\n"
+"POT-Creation-Date: 2020-12-14T13:13:39.539Z\n"
+"PO-Revision-Date: 2020-12-14T13:13:39.539Z\n"
 
 msgid "Data Quality"
 msgstr ""
@@ -15,6 +15,9 @@ msgid "More than 500 values found, please narrow the search to see all"
 msgstr ""
 
 msgid "Updating Organisation Units Tree..."
+msgstr ""
+
+msgid "You do not have access to any organisation units."
 msgstr ""
 
 msgid "DOWNLOAD AS PDF"

--- a/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.js
+++ b/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.js
@@ -47,7 +47,7 @@ class AvailableOrganisationUnitsTree extends PureComponent {
     async loadAvailableOrgUnits() {
         const d2 = this.context.d2
 
-        const orgUnits = await d2.currentUser.getDataViewOrganisationUnits({
+        const orgUnits = await d2.currentUser.getOrganisationUnits({
             fields: 'id,displayName,path,children::isNotEmpty,memberCount',
             paging: false,
         })

--- a/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.js
+++ b/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.js
@@ -61,10 +61,7 @@ class AvailableOrganisationUnitsTree extends PureComponent {
             })
         }
 
-        return d2.currentUser.getDataViewOrganisationUnits({
-            paging: false,
-            fields: 'id,displayName,path,children::isNotEmpty,memberCount',
-        })
+        return orgUnits
     }
 
     handleOrgUnitClick(event, orgUnit) {

--- a/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.test.js
+++ b/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.test.js
@@ -25,8 +25,18 @@ it('AvailableOrganisationUnitsTree does not render OrgUnitTree', () => {
     expect(wrapper.find(OrgUnitTree)).toHaveLength(0)
 })
 
+it('AvailableOrganisationUnitsTree render no access message when no user-org units', () => {
+    const wrapper = ownShallow()
+    wrapper.setState({ rootsWithMembers: [] })
+    expect(
+        wrapper
+            .children()
+            .contains('You do not have access to any organisation units.')
+    ).toBe(true)
+})
+
 it('AvailableOrganisationUnitsTree does render OrgUnitTree', () => {
     const wrapper = ownShallow()
-    wrapper.setState({ rootWithMembers: {} })
+    wrapper.setState({ rootsWithMembers: [{ id: 'someId' }] })
     expect(wrapper.find(OrgUnitTree)).toHaveLength(1)
 })


### PR DESCRIPTION
See https://jira.dhis2.org/browse/DHIS2-6771

Adds support for only selecting user-assigned orgunits, instead of global root-orgunit.
This means that we needed to support multiple roots, as user-assigned OrgUnits can be siblings, not just children of the root. This was done by simply rendering multiple OrgUnit-trees, as I reused the old orgunit tree. However, we may want to update this to the new organisationUnitTree-widget?

There are mulitple "user-assigned" org-units, namely: "Data capture and maintenance organisation units", "Data output and analytic organisation units" and "Search Organisation Units". I am not 100% sure which one to use as the ticket does not specify this, but I reckon it is the second, which is called "dataViewOrganisationUnits" in the API.

Update from Scott: It's actually "data capture and maintenance organisation units". 
 