### PR TITLE
fix(sections): fix missing translations (v35)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-11-01T13:41:47.279Z\n"
-"PO-Revision-Date: 2019-11-01T13:41:47.279Z\n"
+"POT-Creation-Date: 2021-02-01T13:05:04.402Z\n"
+"PO-Revision-Date: 2021-02-01T13:05:04.402Z\n"
 
 msgid "Data Quality"
 msgstr ""
@@ -95,16 +95,45 @@ msgstr ""
 msgid "start"
 msgstr ""
 
+msgid "Validation Rule Analysis"
+msgstr ""
+
+msgid ""
+"Run validation rules in order to unveil anomalies and errors in the data in "
+"the database."
+msgstr ""
+
+msgid "Run Validation"
+msgstr ""
+
 msgid "Std Dev Outlier Analysis"
+msgstr ""
+
+msgid ""
+"Analyze potential outlier values based on standard deviations. Outlier "
+"values can be examined and marked for follow-up."
+msgstr ""
+
+msgid "Analyze"
+msgstr ""
+
+msgid ""
+"Analyze potential outlier values based on min and max values. Outlier "
+"values can be examined and marked for follow-up."
+msgstr ""
+
+msgid ""
+"View or edit data values marked for further follow-up during data entry or "
+"analysis."
+msgstr ""
+
+msgid "View Data Values"
 msgstr ""
 
 msgid "Select number of standard deviations"
 msgstr ""
 
 msgid "Validation passed successfully"
-msgstr ""
-
-msgid "Validation Rule Analysis"
 msgstr ""
 
 msgid "Send Notifications"

--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,7 @@ class App extends PureComponent {
         const translatedSections = sections.map(section =>
             Object.assign(section, {
                 icon: section.info.icon,
-                label: i18n.t(section.info.label),
+                label: section.info.label(),
                 containerElement: <Link to={section.path} />,
             })
         )

--- a/src/pages/home/grid-section/GridSection.js
+++ b/src/pages/home/grid-section/GridSection.js
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom'
 import { GridTile } from 'material-ui/GridList'
 import FontIcon from 'material-ui/FontIcon'
 import classNames from 'classnames'
-import i18n from '@dhis2/d2-i18n'
 import styles from './GridSection.module.css'
 
 class GridSection extends PureComponent {
@@ -35,7 +34,7 @@ class GridSection extends PureComponent {
                                 styles.gridTitleDescription
                             )}
                         >
-                            {this.props.section.info.label}
+                            {this.props.section.info.label()}
                         </span>
                         <FontIcon
                             className={classNames(
@@ -54,7 +53,7 @@ class GridSection extends PureComponent {
                             styles.gridDescription
                         )}
                     >
-                        {i18n.t(this.props.section.info.description)}
+                        {this.props.section.info.description()}
                     </span>
                     <span
                         className={classNames(
@@ -63,7 +62,7 @@ class GridSection extends PureComponent {
                             styles.gridActionText
                         )}
                     >
-                        {i18n.t(this.props.section.info.actionText)}
+                        {this.props.section.info.actionText()}
                     </span>
                 </GridTile>
             </Link>

--- a/src/pages/sections.conf.js
+++ b/src/pages/sections.conf.js
@@ -1,4 +1,5 @@
 import ValidationRulesAnalysis from './validation-rules-analysis/ValidationRulesAnalysis'
+import i18n from '@dhis2/d2-i18n'
 import StdDevOutlierAnalysis from './std-dev-outlier-analysis/StdDevOutlierAnalysis'
 import MinMaxOutlierAnalysis from './min-max-outlier-analysis/MinMaxOutlierAnalysis'
 import FollowUpAnalysis from './follow-up-analysis/FollowUpAnalysis'
@@ -14,11 +15,13 @@ export const sections = [
         path: '/validation-rules-analysis',
         component: ValidationRulesAnalysis,
         info: {
-            label: 'Validation Rule Analysis',
+            label: () => i18n.t('Validation Rule Analysis'),
             icon: 'done_all',
-            description:
-                'Run validation rules in order to unveil anomalies and errors in the data in the database.',
-            actionText: 'Run Validation',
+            description: () =>
+                i18n.t(
+                    'Run validation rules in order to unveil anomalies and errors in the data in the database.'
+                ),
+            actionText: () => i18n.t('Run Validation'),
             docs: 'validation_rule_analysis',
         },
     },
@@ -27,11 +30,13 @@ export const sections = [
         path: '/std-dev-outlier-analysis',
         component: StdDevOutlierAnalysis,
         info: {
-            label: 'Std Dev Outlier Analysis',
+            label: () => i18n.t('Std Dev Outlier Analysis'),
             icon: 'show_chart',
-            description:
-                'Analyze potential outlier values based on standard deviations. Outlier values can be examined and marked for follow-up.',
-            actionText: 'Analyze',
+            description: () =>
+                i18n.t(
+                    'Analyze potential outlier values based on standard deviations. Outlier values can be examined and marked for follow-up.'
+                ),
+            actionText: () => i18n.t('Analyze'),
             docs: 'standard_deviation_analysis',
         },
     },
@@ -40,11 +45,13 @@ export const sections = [
         path: '/min-max-outlier-analysis',
         component: MinMaxOutlierAnalysis,
         info: {
-            label: 'Min-Max Outlier Analysis',
+            label: () => i18n.t('Min-Max Outlier Analysis'),
             icon: 'compare_arrows',
-            description:
-                'Analyze potential outlier values based on min and max values. Outlier values can be examined and marked for follow-up.',
-            actionText: 'Analyze',
+            description: () =>
+                i18n.t(
+                    'Analyze potential outlier values based on min and max values. Outlier values can be examined and marked for follow-up.'
+                ),
+            actionText: () => i18n.t('Analyze'),
             docs: 'min_max_analysis',
         },
     },
@@ -53,11 +60,13 @@ export const sections = [
         path: '/follow-up-analysis',
         component: FollowUpAnalysis,
         info: {
-            label: 'Follow-Up Analysis',
+            label: () => i18n.t('Follow-Up Analysis'),
             icon: 'description',
-            description:
-                'View or edit data values marked for further follow-up during data entry or analysis.',
-            actionText: 'View Data Values',
+            description: () =>
+                i18n.t(
+                    'View or edit data values marked for further follow-up during data entry or analysis.'
+                ),
+            actionText: () => i18n.t('View Data Values'),
             docs: 'follow_up_analysis',
         },
     },


### PR DESCRIPTION
A note on these backports: since the sections have changed in v36 I couldn't really cherry pick my changes from master. Instead I manually created this backport. So it's probably a good idea to code-review and test at least one of the backport PRs thoroughly.