### PR TITLE
fix: use correct endpoint for updating marked data values

### DIFF
--- a/src/pages/follow-up-analysis/FollowUpAnalysis.js
+++ b/src/pages/follow-up-analysis/FollowUpAnalysis.js
@@ -171,7 +171,7 @@ class FollowUpAnalysis extends Page {
             },
         })
 
-        api.post(apiConf.endpoints.markDataValue, {
+        api.post(apiConf.endpoints.updateMarkDataValue, {
             followups: unfollowups,
         })
             .then(() => {

--- a/src/pages/follow-up-analysis/FollowUpAnalysis.js
+++ b/src/pages/follow-up-analysis/FollowUpAnalysis.js
@@ -171,7 +171,7 @@ class FollowUpAnalysis extends Page {
             },
         })
 
-        api.post(apiConf.endpoints.updateMarkDataValue, {
+        api.post(apiConf.endpoints.markFollowUpDataValue, {
             followups: unfollowups,
         })
             .then(() => {

--- a/src/pages/outlier-detection/OutlierDetection.js
+++ b/src/pages/outlier-detection/OutlierDetection.js
@@ -286,7 +286,7 @@ class OutlierDetection extends Page {
         const data = OutlierAnalyisTable.convertElementToToggleFollowupRequest(
             currentElement
         )
-        api.update(apiConf.endpoints.markDataValue, data)
+        api.update(apiConf.endpoints.markOutlierDataValue, data)
             .then(() => {
                 if (this.isPageMounted()) {
                     const updatedElement = {

--- a/src/server.conf.js
+++ b/src/server.conf.js
@@ -6,8 +6,8 @@ export const apiConf = {
         validationRules: '/validationRules',
         outlierDetection: '/outlierDetection',
         folloupAnalysis: '/dataAnalysis/followup',
-        markDataValue: '/dataValues/followup',
-        updateMarkDataValue: '/dataAnalysis/followup/mark',
+        markOutlierDataValue: '/dataValues/followup',
+        markFollowUpDataValue: '/dataAnalysis/followup/mark',
         reportAnalysis: '/dataAnalysis/report',
     },
     results: {

--- a/src/server.conf.js
+++ b/src/server.conf.js
@@ -7,6 +7,7 @@ export const apiConf = {
         outlierDetection: '/outlierDetection',
         folloupAnalysis: '/dataAnalysis/followup',
         markDataValue: '/dataValues/followup',
+        updateMarkDataValue: '/dataAnalysis/followup/mark',
         reportAnalysis: '/dataAnalysis/report',
     },
     results: {


### PR DESCRIPTION
The `/dataValues/followup` does not support `POST` and so the correct endpoint for updating marked data values is `/dataAnalysis/followup/mark`.