### PR TITLE
fix(org-unit-tree): load user org units

### DIFF
--- a/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.js
+++ b/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.js
@@ -79,12 +79,16 @@ const AvailableOrganisationUnitsTree = ({ multiselect = false, onChange }) => {
     }
 
     const handleOrgUnitClickSingle = ({ id, path }) => {
+        let selectedId = id
         if (selected.has(path)) {
-            return
+            //deselect
+            selectedId = null
+            setSelected(new Map())
+        } else {
+            setSelected(new Map().set(path, id))
         }
-        setSelected(new Map().set(path, id))
         if (onChange) {
-            onChange(id)
+            onChange(selectedId)
         }
     }
 

--- a/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.js
+++ b/src/components/available-organisation-units-tree/AvailableOrganisationUnitsTree.js
@@ -22,7 +22,6 @@ const query = {
         resource: 'me',
         params: {
             fields: 'organisationUnits, authorities',
-            paging: false,
         },
     },
 }


### PR DESCRIPTION
This PR fixes a couple of things with the org-unit tree

- Loads only the root org-units the user is assigned to
-  Fixes singles-select and deselect of org-units

https://jira.dhis2.org/browse/DHIS2-10771