### PR TITLE
fix(validation rule analysis): send correct persist & notification values

### DIFF
--- a/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
+++ b/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
@@ -73,8 +73,8 @@ class ValidationRulesAnalysis extends Page {
             startDate: convertDateToApiDateFormat(this.state.startDate),
             endDate: convertDateToApiDateFormat(this.state.endDate),
             ou: this.state.organisationUnitId,
-            notification: this.state.notification,
-            persist: this.state.persist,
+            notification: this.state.sendNotfications,
+            persist: this.state.persistNewResults,
         }
         if (
             this.state.validationRuleGroupId !== ALL_VALIDATION_RULE_GROUPS_ID


### PR DESCRIPTION
Fixes [DHIS2-10815](https://jira.dhis2.org/browse/DHIS2-10815)

* Uses the correct form state properties to extract the `persist` and `notification` request params