### PR TITLE
fix: update end dates for visualisation analysis and outliers

### DIFF
--- a/src/pages/outlier-detection/Form.js
+++ b/src/pages/outlier-detection/Form.js
@@ -90,20 +90,40 @@ const ZScoreFields = ({
         </Button>
         {showAdvancedZScoreFields && (
             <>
-                <DatePicker
-                    textFieldStyle={jsPageStyles.inputForm}
-                    floatingLabelText={i18n.t('Data start date')}
-                    onChange={onDataStartDateChange}
-                    maxDate={dataEndDate}
-                    value={dataStartDate}
-                />
-                <DatePicker
-                    textFieldStyle={jsPageStyles.inputForm}
-                    floatingLabelText={i18n.t('Data end date')}
-                    onChange={onDataEndDateChange}
-                    minDate={dataStartDate}
-                    value={dataEndDate}
-                />
+                <div className={styles.optionalDatepickerContainer}>
+                    <DatePicker
+                        textFieldStyle={jsPageStyles.inputForm}
+                        floatingLabelText={i18n.t('Data start date')}
+                        onChange={(event, date) => onDataStartDateChange(date)}
+                        maxDate={dataEndDate}
+                        value={dataStartDate}
+                    />
+                    <Button
+                        secondary
+                        small
+                        disabled={!dataStartDate}
+                        onClick={() => onDataStartDateChange(null)}
+                    >
+                        {i18n.t('Clear')}
+                    </Button>
+                </div>
+                <div className={styles.optionalDatepickerContainer}>
+                    <DatePicker
+                        textFieldStyle={jsPageStyles.inputForm}
+                        floatingLabelText={i18n.t('Data end date')}
+                        onChange={(event, date) => onDataEndDateChange(date)}
+                        minDate={dataStartDate}
+                        value={dataEndDate}
+                    />
+                    <Button
+                        secondary
+                        small
+                        disabled={!dataEndDate}
+                        onClick={() => onDataEndDateChange(null)}
+                    >
+                        {i18n.t('Clear')}
+                    </Button>
+                </div>
                 <SelectField
                     style={jsPageStyles.inputForm}
                     floatingLabelText={i18n.t('Sort by')}

--- a/src/pages/outlier-detection/Form.module.css
+++ b/src/pages/outlier-detection/Form.module.css
@@ -1,3 +1,12 @@
 .toggleBtn {
     margin-top: var(--spacers-dp12);
 }
+
+.optionalDatepickerContainer {
+    display: flex;
+    align-items: baseline;
+}
+
+.optionalDatepickerContainer button {
+    margin-left: var(--spacers-dp8);
+}

--- a/src/pages/outlier-detection/OutlierDetection.js
+++ b/src/pages/outlier-detection/OutlierDetection.js
@@ -154,12 +154,12 @@ class OutlierDetection extends Page {
         this.setState({ endDate: new Date(date) })
     }
 
-    handleDataStartDateChange = (event, date) => {
-        this.setState({ dataStartDate: new Date(date) })
+    handleDataStartDateChange = date => {
+        this.setState({ dataStartDate: date && new Date(date) })
     }
 
-    handleDataEndDateChange = (event, date) => {
-        this.setState({ dataEndDate: new Date(date) })
+    handleDataEndDateChange = date => {
+        this.setState({ dataEndDate: date && new Date(date) })
     }
 
     handleMaxResultsChange = (event, index, value) => {

--- a/src/pages/outlier-detection/OutlierDetection.js
+++ b/src/pages/outlier-detection/OutlierDetection.js
@@ -150,7 +150,7 @@ class OutlierDetection extends Page {
         this.setState({ startDate: new Date(date) })
     }
 
-    handleEndDateOnChange = (event, date) => {
+    handleEndDateChange = (event, date) => {
         this.setState({ endDate: new Date(date) })
     }
 

--- a/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
+++ b/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
@@ -194,6 +194,7 @@ class ValidationRulesAnalysis extends Page {
                             startDate={this.state.startDate}
                             onStartDateChange={this.handleStartDateChange}
                             endDate={this.state.endDate}
+                            onEndDateChange={this.handleEndDateChange}
                             onValidationRuleGroupChange={
                                 this.handleValidationRuleGroupChange
                             }


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-10813

Fixes the following issues:

- The validation analysis and outliers pages did not pass end date event handlers to their `Form` components so that state was not updated.
- There was no way to clear data start/end dates.