### PR TITLE
fix: preserve org-unit state when navigating back from table

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-02T13:20:58.188Z\n"
-"PO-Revision-Date: 2021-03-02T13:20:58.188Z\n"
+"POT-Creation-Date: 2021-04-06T20:10:13.953Z\n"
+"PO-Revision-Date: 2021-04-06T20:10:13.953Z\n"
 
 msgid "More than 500 values found, please narrow the search to see all"
 msgstr ""
@@ -123,6 +123,9 @@ msgid "Show advanced options"
 msgstr ""
 
 msgid "Data start date"
+msgstr ""
+
+msgid "Clear"
 msgstr ""
 
 msgid "Data end date"

--- a/src/pages/follow-up-analysis/FollowUpAnalysis.js
+++ b/src/pages/follow-up-analysis/FollowUpAnalysis.js
@@ -201,7 +201,12 @@ class FollowUpAnalysis extends Page {
                 </header>
                 <AlertBar show={this.showAlertBar()} />
                 <Card className={cssPageStyles.card}>
-                    {!this.state.showTable && (
+                    {/* Hide form instead of not rendering to preserve org unit state */}
+                    <div
+                        style={{
+                            display: this.state.showTable ? 'none' : 'block',
+                        }}
+                    >
                         <Form
                             onSubmit={this.getFollowUpList}
                             submitDisabled={this.isActionDisabled()}
@@ -215,7 +220,7 @@ class FollowUpAnalysis extends Page {
                             endDate={this.state.endDate}
                             onEndDateChange={this.endDateOnChange}
                         />
-                    )}
+                    </div>
                     {this.state.showTable && (
                         <FollowUpAnalysisTable
                             elements={this.state.elements}

--- a/src/pages/outlier-detection/OutlierDetection.js
+++ b/src/pages/outlier-detection/OutlierDetection.js
@@ -285,8 +285,12 @@ class OutlierDetection extends Page {
                 </header>
                 <AlertBar show={this.showAlertBar()} />
                 <Card className={cssPageStyles.card}>
-                    {/* FORM: hidden to avoid not needed api requests when going back from table */}
-                    {!this.state.showTable && (
+                    {/* Hide form instead of not rendering to preserve org unit state */}
+                    <div
+                        style={{
+                            display: this.state.showTable ? 'none' : 'block',
+                        }}
+                    >
                         <Form
                             onSubmit={this.start}
                             submitDisabled={this.isActionDisabled()}
@@ -320,7 +324,7 @@ class OutlierDetection extends Page {
                             onStartDateChange={this.handleStartDateChange}
                             onEndDateChange={this.handleEndDateChange}
                         />
-                    )}
+                    </div>
                     {this.state.showTable && this.state.csvQueryStr && (
                         <OutlierAnalyisTable
                             algorithm={this.state.algorithm}

--- a/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
+++ b/src/pages/validation-rules-analysis/ValidationRulesAnalysis.js
@@ -184,7 +184,12 @@ class ValidationRulesAnalysis extends Page {
                 </header>
                 <AlertBar show={this.showAlertBar()} />
                 <Card className={cssPageStyles.card}>
-                    {!this.state.showTable && (
+                    {/* Hide form instead of not rendering to preserve org unit state */}
+                    <div
+                        style={{
+                            display: this.state.showTable ? 'none' : 'block',
+                        }}
+                    >
                         <Form
                             onSubmit={this.validate}
                             submitDisabled={this.isActionDisabled()}
@@ -207,7 +212,7 @@ class ValidationRulesAnalysis extends Page {
                                 this.handlePersistNewResultsChange
                             }
                         />
-                    )}
+                    </div>
                     {this.state.showTable && (
                         <ValidationRulesAnalysisTable
                             elements={this.state.elements}


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-10851

In order to preserve the state of the org unit components prior to the rendering of tabular results, their parent `Form` components are hidden using CSS instead of not being rendered at all.