### PR TITLE
feat: use new followups API [DHIS2-10658]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-04-30T10:36:52.680Z\n"
-"PO-Revision-Date: 2021-04-30T10:36:52.680Z\n"
+"POT-Creation-Date: 2021-04-30T13:25:32.427Z\n"
+"PO-Revision-Date: 2021-04-30T13:25:32.427Z\n"
 
 msgid "More than 500 values found, please narrow the search to see all"
 msgstr ""
@@ -98,10 +98,10 @@ msgstr ""
 msgid "End Date"
 msgstr ""
 
-msgid "Unfollow"
+msgid "Unfollow elements"
 msgstr ""
 
-msgid "unfollow"
+msgid "Unfollow"
 msgstr ""
 
 msgid "Start"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-04-30T10:22:05.126Z\n"
-"PO-Revision-Date: 2021-04-30T10:22:05.126Z\n"
+"POT-Creation-Date: 2021-04-30T10:36:52.680Z\n"
+"PO-Revision-Date: 2021-04-30T10:36:52.680Z\n"
 
 msgid "More than 500 values found, please narrow the search to see all"
 msgstr ""
@@ -96,9 +96,6 @@ msgid "Start Date"
 msgstr ""
 
 msgid "End Date"
-msgstr ""
-
-msgid "Close"
 msgstr ""
 
 msgid "Unfollow"
@@ -210,6 +207,9 @@ msgid "Operator"
 msgstr ""
 
 msgid "Details"
+msgstr ""
+
+msgid "Close"
 msgstr ""
 
 msgid "VALIDATIONS RESULT DETAILS"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-04-06T20:10:13.953Z\n"
-"PO-Revision-Date: 2021-04-06T20:10:13.953Z\n"
+"POT-Creation-Date: 2021-04-30T10:22:05.126Z\n"
+"PO-Revision-Date: 2021-04-30T10:22:05.126Z\n"
 
 msgid "More than 500 values found, please narrow the search to see all"
 msgstr ""
@@ -99,9 +99,6 @@ msgid "End Date"
 msgstr ""
 
 msgid "Close"
-msgstr ""
-
-msgid "Comment"
 msgstr ""
 
 msgid "Unfollow"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-04-30T13:25:32.427Z\n"
-"PO-Revision-Date: 2021-04-30T13:25:32.427Z\n"
+"POT-Creation-Date: 2021-05-07T11:15:43.680Z\n"
+"PO-Revision-Date: 2021-05-07T11:15:43.680Z\n"
 
 msgid "More than 500 values found, please narrow the search to see all"
 msgstr ""
@@ -102,6 +102,9 @@ msgid "Unfollow elements"
 msgstr ""
 
 msgid "Unfollow"
+msgstr ""
+
+msgid "Comment"
 msgstr ""
 
 msgid "Start"

--- a/src/components/download-as/DownloadAs.module.css
+++ b/src/components/download-as/DownloadAs.module.css
@@ -1,10 +1,11 @@
-.downloadAs {
-    color: #757575;
-    font-size: 12px;
-}
 .downloadAs a {
     margin-left: 20px;
-    color: inherit;
-    font-size: inherit;
+    color: var(--colors-grey700);
+    font-size: 12px;
     text-decoration: none;
+}
+
+.downloadAs a:hover, .downloadAs a:focus {
+    color: var(--colors-grey900);
+    text-decoration: underline;
 }

--- a/src/components/formatters/FormattedNumber.js
+++ b/src/components/formatters/FormattedNumber.js
@@ -8,10 +8,11 @@ const FormattedNumber = ({
     maximumFractionDigits,
 }) => (
     <span>
-        {typeof value === 'number' && new Intl.NumberFormat(i18n.language, {
-            minimumFractionDigits,
-            maximumFractionDigits,
-        }).format(value)}
+        {typeof value === 'number' &&
+            new Intl.NumberFormat(i18n.language, {
+                minimumFractionDigits,
+                maximumFractionDigits,
+            }).format(value)}
     </span>
 )
 

--- a/src/components/formatters/FormattedNumber.js
+++ b/src/components/formatters/FormattedNumber.js
@@ -8,7 +8,7 @@ const FormattedNumber = ({
     maximumFractionDigits,
 }) => (
     <span>
-        {new Intl.NumberFormat(i18n.language, {
+        {typeof value === 'number' && new Intl.NumberFormat(i18n.language, {
             minimumFractionDigits,
             maximumFractionDigits,
         }).format(value)}

--- a/src/pages/Page.module.css
+++ b/src/pages/Page.module.css
@@ -90,3 +90,7 @@
 .checkboxWrapper > div > div > div {
     margin: 0px !important;
 }
+
+.tableBackButton {
+    margin-right: var(--spacers-dp8);
+}

--- a/src/pages/follow-up-analysis/FollowUpAnalysis.js
+++ b/src/pages/follow-up-analysis/FollowUpAnalysis.js
@@ -148,7 +148,7 @@ class FollowUpAnalysis extends Page {
 
         const api = this.context.d2.Api.getApi()
         await api.update(apiConf.endpoints.markFollowups, {
-            followups: unfollowups,
+            values: unfollowups,
         })
         if (!this.isPageMounted()) {
             return

--- a/src/pages/follow-up-analysis/FollowUpAnalysis.js
+++ b/src/pages/follow-up-analysis/FollowUpAnalysis.js
@@ -131,8 +131,7 @@ class FollowUpAnalysis extends Page {
         })
 
         const api = this.context.d2.Api.getApi()
-        // TODO: Use new API with UIDs
-        await api.post(apiConf.endpoints.markFollowUpDataValue, {
+        await api.update(apiConf.endpoints.markFollowups, {
             followups: unfollowups,
         })
         if (!this.isPageMounted()) {

--- a/src/pages/follow-up-analysis/FollowUpAnalysis.js
+++ b/src/pages/follow-up-analysis/FollowUpAnalysis.js
@@ -13,15 +13,6 @@ import { getDocsKeyForSection } from '../sections.conf'
 import FollowUpAnalysisTable from './follow-up-analysis-table/FollowUpAnalysisTable'
 import Form from './Form'
 
-const elementsEqual = (element1, element2) =>
-    [
-        'attributeOptionComboId',
-        'categoryOptionComboId',
-        'periodId',
-        'organisationUnitId',
-        'dataElementId',
-    ].every(key => element1[key] === element2[key])
-
 const convertElementFromApiResponse = e => ({
     key: `${e.aoc}-${e.coc}-${e.pe}-${e.ou}-${e.de}`,
     attributeOptionComboId: e.aoc,
@@ -164,8 +155,9 @@ class FollowUpAnalysis extends Page {
         }
 
         // remove unfollowed elements
-        const elements = this.state.elements.filter(element =>
-            unfollowups.every(unfollow => !elementsEqual(element, unfollow))
+        const elements = this.state.elements.filter(
+            element =>
+                !unfollowups.some(unfollow => element.key === unfollow.key)
         )
         this.context.updateAppState({
             pageState: {

--- a/src/pages/follow-up-analysis/FollowUpAnalysis.js
+++ b/src/pages/follow-up-analysis/FollowUpAnalysis.js
@@ -64,17 +64,18 @@ class FollowUpAnalysis extends Page {
             ou: this.state.organisationUnitId,
             ds: this.state.dataSetIds,
         }
-        const response = await api.post(
-            apiConf.endpoints.folloupAnalysis,
+        const response = await api.get(
+            apiConf.endpoints.followupAnalysis,
             request
         )
         if (!this.isPageMounted()) {
             return
         }
 
-        const elements = response.map(
+        const elements = response.followupValues.map(
             FollowUpAnalysisTable.convertElementFromApiResponse
         )
+
         this.context.updateAppState({
             pageState: {
                 loading: false,
@@ -130,6 +131,7 @@ class FollowUpAnalysis extends Page {
         })
 
         const api = this.context.d2.Api.getApi()
+        // TODO: Use new API with UIDs
         await api.post(apiConf.endpoints.markFollowUpDataValue, {
             followups: unfollowups,
         })

--- a/src/pages/follow-up-analysis/FollowUpAnalysis.js
+++ b/src/pages/follow-up-analysis/FollowUpAnalysis.js
@@ -26,6 +26,7 @@ const convertElementFromApiResponse = e => ({
     min: e.min,
     max: e.max,
     value: Number.parseFloat(e.value, 10),
+    comment: e.comment,
     marked: false,
 })
 

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
@@ -48,11 +48,11 @@ class FollowUpAnalysisTable extends Component {
     })
 
     static convertElementToUnFollowupRequest = e => ({
-        dataElementId: e.dataElementId,
-        periodId: e.periodId,
-        organisationUnitId: e.organisationUnitId,
-        categoryOptionComboId: e.categoryOptionComboId,
-        attributeOptionComboId: e.attributeOptionComboId,
+        dataElement: e.dataElementId,
+        period: e.periodId,
+        orgUnit: e.organisationUnitId,
+        categoryOptionCombo: e.categoryOptionComboId,
+        attributeOptionCombo: e.attributeOptionComboId,
         followup: false,
     })
 

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
@@ -25,6 +25,7 @@ import cssPageStyles from '../../Page.module.css'
 import styles from './FollowUpAnalysisTable.module.css'
 
 const convertElementToUnFollowupRequest = e => ({
+    key: `${e.attributeOptionComboId}-${e.categoryOptionComboId}-${e.periodId}-${e.organisationUnitId}-${e.dataElementId}`,
     dataElement: e.dataElementId,
     period: e.periodId,
     orgUnit: e.organisationUnitId,

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
@@ -35,24 +35,20 @@ class FollowUpAnalysisTable extends Component {
         d2: PropTypes.object,
     }
 
-    static generateElementKey = e =>
-        `${e.attributeOptionComboId}-${e.categoryOptionComboId}-${e.periodId}-${e.sourceId}-${e.dataElementId}`
-
     static convertElementFromApiResponse = e => ({
-        key: FollowUpAnalysisTable.generateElementKey(e),
-        attributeOptionComboId: e.attributeOptionComboId,
-        categoryOptionComboId: e.categoryOptionComboId,
-        periodId: e.periodId,
-        organisationUnitId: e.sourceId,
-        dataElementId: e.dataElementId,
-        dataElement: e.dataElementName,
-        organisation: e.sourceName,
-        period: e.period.name,
+        key: `${e.aoc}-${e.coc}-${e.pe}-${e.ou}-${e.de}`,
+        attributeOptionComboId: e.aoc,
+        categoryOptionComboId: e.coc,
+        periodId: e.pe,
+        period: e.pe,
+        organisationUnitId: e.ou,
+        organisation: e.ouName,
+        dataElementId: e.de,
+        dataElement: e.deName,
         min: e.min,
         max: e.max,
         value: Number.parseFloat(e.value, 10),
-        marked: !e.followup,
-        comment: e.comment,
+        marked: false,
     })
 
     static convertElementToUnFollowupRequest = e => ({

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
@@ -9,15 +9,29 @@ import {
     TableBody,
     TableRow,
     TableCell,
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    ButtonStrip,
 } from '@dhis2/ui'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import DownloadAs from '../../../components/download-as/DownloadAs'
 import FormattedNumber from '../../../components/formatters/FormattedNumber'
 import { apiConf } from '../../../server.conf'
 import cssPageStyles from '../../Page.module.css'
 import styles from './FollowUpAnalysisTable.module.css'
+
+const convertElementToUnFollowupRequest = e => ({
+    dataElement: e.dataElementId,
+    period: e.periodId,
+    orgUnit: e.organisationUnitId,
+    categoryOptionCombo: e.categoryOptionComboId,
+    attributeOptionCombo: e.attributeOptionComboId,
+    followup: false,
+})
 
 const Footer = ({ submitButtonDisabled, onSubmit }) => (
     <div
@@ -38,16 +52,34 @@ Footer.propTypes = {
     onSubmit: PropTypes.func.isRequired,
 }
 
-const convertElementToUnFollowupRequest = e => ({
-    dataElement: e.dataElementId,
-    period: e.periodId,
-    orgUnit: e.organisationUnitId,
-    categoryOptionCombo: e.categoryOptionComboId,
-    attributeOptionCombo: e.attributeOptionComboId,
-    followup: false,
-})
+const CommentModal = ({ comment, onClose }) => (
+    <Modal>
+        <ModalTitle>Comment</ModalTitle>
+        <ModalContent>{comment}</ModalContent>
+        <ModalActions>
+            <ButtonStrip end>
+                <Button secondary onClick={onClose}>
+                    Close
+                </Button>
+            </ButtonStrip>
+        </ModalActions>
+    </Modal>
+)
+
+CommentModal.propTypes = {
+    comment: PropTypes.string.isRequired,
+    onClose: PropTypes.func.isRequired,
+}
 
 const ElementRow = ({ element, onCheckboxToggle }) => {
+    const [isCommentVisible, setIsCommentVisible] = useState(false)
+
+    const handleShowComment = () => {
+        setIsCommentVisible(true)
+    }
+    const handleHideComment = () => {
+        setIsCommentVisible(false)
+    }
     const handleMarkedToggle = () => {
         onCheckboxToggle(element)
     }
@@ -66,11 +98,27 @@ const ElementRow = ({ element, onCheckboxToggle }) => {
             <TableCell className={styles.formattedNumberColumn}>
                 <FormattedNumber value={element.max} />
             </TableCell>
-            <TableCell className={cssPageStyles.centerFlex}>
+            <TableCell>
                 <Checkbox
+                    className={styles.centeredCheckbox}
                     checked={element.marked}
                     onChange={handleMarkedToggle}
                 />
+            </TableCell>
+            <TableCell className={styles.commentColumn}>
+                {element.comment && (
+                    <>
+                        {isCommentVisible && (
+                            <CommentModal
+                                comment={element.comment}
+                                onClose={handleHideComment}
+                            />
+                        )}
+                        <Button small secondary onClick={handleShowComment}>
+                            View comment
+                        </Button>
+                    </>
+                )}
             </TableCell>
         </TableRow>
     )
@@ -118,6 +166,9 @@ const FollowUpAnalysisTable = ({
                         </TableCellHead>
                         <TableCellHead className={cssPageStyles.center}>
                             {i18n.t('Unfollow')}
+                        </TableCellHead>
+                        <TableCellHead className={cssPageStyles.center}>
+                            {i18n.t('Comment')}
                         </TableCellHead>
                     </TableRowHead>
                 </TableHead>

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
@@ -87,7 +87,9 @@ const ElementRow = ({ element, onCheckboxToggle }) => {
 
     return (
         <TableRow>
-            <TableCell>{element.dataElement}</TableCell>
+            <TableCell className={styles.dataElementColumn}>
+                {element.dataElement}
+            </TableCell>
             <TableCell>{element.organisation}</TableCell>
             <TableCell>{element.period}</TableCell>
             <TableCell className={styles.formattedNumberColumn}>

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
@@ -2,7 +2,6 @@ import i18n from '@dhis2/d2-i18n'
 import classNames from 'classnames'
 import {
     Checkbox,
-    FontIcon,
     RaisedButton,
     Table,
     TableBody,
@@ -10,9 +9,6 @@ import {
     TableHeaderColumn,
     TableRow,
     TableRowColumn,
-    IconButton,
-    Dialog,
-    FlatButton,
 } from 'material-ui'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -71,72 +67,18 @@ class FollowUpAnalysisTable extends Component {
         )
     }
 
-    constructor() {
-        super()
-
-        this.state = {
-            showComment: false,
-            comment: null,
-        }
-
-        this.unfollow = this.unfollow.bind(this)
-        this.closeCommentDialog = this.closeCommentDialog.bind(this)
-    }
-
-    unfollow() {
-        const unfollowups = []
-        for (let i = 0; i < this.props.elements.length; i++) {
-            const e = this.props.elements[i]
-            if (e.marked) {
-                unfollowups.push(
-                    FollowUpAnalysisTable.convertElementToUnFollowupRequest(e)
-                )
-            }
-        }
-
+    handleUnfollowMarked = () => {
+        const unfollowups = this.props.elements
+            .filter(element => element.marked)
+            .map(FollowUpAnalysisTable.convertElementToUnFollowupRequest)
         this.props.unfollow(unfollowups)
     }
 
-    closeCommentDialog() {
-        this.setState({ showComment: false })
-    }
-
-    updateCheckbox(element) {
-        this.props.toggleCheckbox(element)
-    }
-
-    showComment(element) {
-        if (element.comment) {
-            this.setState({
-                showComment: true,
-                comment: element.comment,
-            })
-        }
-    }
-
     render() {
-        let oneChecked = false
-
-        const commentDialogActions = [
-            <FlatButton
-                key={'close'}
-                label={i18n.t('Close')}
-                primary
-                onClick={this.closeCommentDialog}
-            />,
-        ]
-
-        // Table Rows
         const rows = this.props.elements.map(element => {
-            const updateCheckbox = () => {
-                this.updateCheckbox(element)
+            const handleMarkedToggle = () => {
+                this.props.toggleCheckbox(element)
             }
-
-            const showComment = () => {
-                this.showComment(element)
-            }
-
-            oneChecked = element.marked ? true : oneChecked
 
             return (
                 <TableRow key={element.key}>
@@ -156,22 +98,10 @@ class FollowUpAnalysisTable extends Component {
                         <span className={cssPageStyles.checkboxWrapper}>
                             <Checkbox
                                 checked={element.marked}
-                                onCheck={updateCheckbox}
+                                onCheck={handleMarkedToggle}
                                 iconStyle={jsPageStyles.iconColor}
                             />
                         </span>
-                    </TableRowColumn>
-                    <TableRowColumn className={cssPageStyles.center}>
-                        {element.comment && (
-                            <IconButton key={element.key} onClick={showComment}>
-                                <FontIcon
-                                    className={'material-icons'}
-                                    style={jsPageStyles.cursorStyle}
-                                >
-                                    speaker_notes
-                                </FontIcon>
-                            </IconButton>
-                        )}
                     </TableRowColumn>
                 </TableRow>
             )
@@ -179,15 +109,6 @@ class FollowUpAnalysisTable extends Component {
 
         return (
             <div>
-                <Dialog
-                    title={i18n.t('Comment')}
-                    actions={commentDialogActions}
-                    modal={false}
-                    open={this.state.showComment}
-                    onRequestClose={this.closeCommentDialog}
-                >
-                    <div id={'comment-content'}>{this.state.comment}</div>
-                </Dialog>
                 <div className={cssPageStyles.cardHeader}>
                     <DownloadAs endpoint={apiConf.endpoints.reportAnalysis} />
                 </div>
@@ -225,9 +146,6 @@ class FollowUpAnalysisTable extends Component {
                             <TableHeaderColumn className={cssPageStyles.center}>
                                 {i18n.t('Unfollow')}
                             </TableHeaderColumn>
-                            <TableHeaderColumn className={cssPageStyles.center}>
-                                {i18n.t('Comment')}
-                            </TableHeaderColumn>
                         </TableRow>
                     </TableHeader>
                     <TableBody displayRowCheckbox={false} stripedRows={false}>
@@ -241,11 +159,13 @@ class FollowUpAnalysisTable extends Component {
                     )}
                 >
                     <RaisedButton
-                        id="unfollow-action"
                         primary
-                        disabled={this.props.loading || !oneChecked}
+                        disabled={
+                            this.props.loading ||
+                            !this.props.elements.some(e => e.marked)
+                        }
                         label={i18n.t('unfollow')}
-                        onClick={this.unfollow}
+                        onClick={this.handleUnfollowMarked}
                     />
                     <DownloadAs endpoint={apiConf.endpoints.reportAnalysis} />
                 </div>

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.js
@@ -57,13 +57,13 @@ const ElementRow = ({ element, onCheckboxToggle }) => {
             <TableCell>{element.dataElement}</TableCell>
             <TableCell>{element.organisation}</TableCell>
             <TableCell>{element.period}</TableCell>
-            <TableCell className={cssPageStyles.right}>
+            <TableCell className={styles.formattedNumberColumn}>
                 <FormattedNumber value={element.min} />
             </TableCell>
-            <TableCell className={cssPageStyles.right}>
+            <TableCell className={styles.formattedNumberColumn}>
                 <FormattedNumber value={element.value} />
             </TableCell>
-            <TableCell className={cssPageStyles.right}>
+            <TableCell className={styles.formattedNumberColumn}>
                 <FormattedNumber value={element.max} />
             </TableCell>
             <TableCell className={cssPageStyles.centerFlex}>
@@ -99,7 +99,7 @@ const FollowUpAnalysisTable = ({
             <div className={cssPageStyles.cardHeader}>
                 <DownloadAs endpoint={apiConf.endpoints.reportAnalysis} />
             </div>
-            <Table className={styles.followUpAnalysisTable}>
+            <Table>
                 <TableHead>
                     <TableRowHead>
                         <TableCellHead>{i18n.t('Data Element')}</TableCellHead>
@@ -107,13 +107,13 @@ const FollowUpAnalysisTable = ({
                             {i18n.t('Organisation Unit')}
                         </TableCellHead>
                         <TableCellHead>{i18n.t('Period')}</TableCellHead>
-                        <TableCellHead className={cssPageStyles.right}>
+                        <TableCellHead className={styles.formattedNumberColumn}>
                             {i18n.t('Min')}
                         </TableCellHead>
-                        <TableCellHead className={cssPageStyles.right}>
+                        <TableCellHead className={styles.formattedNumberColumn}>
                             {i18n.t('Value')}
                         </TableCellHead>
-                        <TableCellHead className={cssPageStyles.right}>
+                        <TableCellHead className={styles.formattedNumberColumn}>
                             {i18n.t('Max')}
                         </TableCellHead>
                         <TableCellHead className={cssPageStyles.center}>

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.module.css
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.module.css
@@ -2,3 +2,11 @@
     overflow: visible !important;
     text-align: right !important;
 }
+
+.centeredCheckbox {
+    justify-content: center !important;
+}
+
+.commentColumn {
+    text-align: center;
+}

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.module.css
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.module.css
@@ -1,5 +1,4 @@
-.followUpAnalysisTable td:nth-child(4),
-.followUpAnalysisTable td:nth-child(5),
-.followUpAnalysisTable td:nth-child(6) {
+.formattedNumberColumn {
     overflow: visible !important;
+    text-align: right !important;
 }

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.module.css
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.module.css
@@ -1,3 +1,7 @@
+.dataElementColumn {
+    max-width: 20vw;
+}
+
 .formattedNumberColumn {
     overflow: visible !important;
     text-align: right !important;

--- a/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.module.css
+++ b/src/pages/follow-up-analysis/follow-up-analysis-table/FollowUpAnalysisTable.module.css
@@ -1,7 +1,5 @@
-.followUpAnalysisTable
-    td:nth-child(4),
-    td:nth-child(5),
-    td:nth-child(6)
-    {
-        overflow: visible !important;
-    }
+.followUpAnalysisTable td:nth-child(4),
+.followUpAnalysisTable td:nth-child(5),
+.followUpAnalysisTable td:nth-child(6) {
+    overflow: visible !important;
+}

--- a/src/pages/outlier-detection/OutlierDetection.js
+++ b/src/pages/outlier-detection/OutlierDetection.js
@@ -223,7 +223,7 @@ class OutlierDetection extends Page {
             currentElement
         )
         const api = this.context.d2.Api.getApi()
-        await api.update(apiConf.endpoints.markOutlierDataValue, data)
+        await api.update(apiConf.endpoints.markOutlier, data)
         if (!this.isPageMounted()) {
             return
         }

--- a/src/server.conf.js
+++ b/src/server.conf.js
@@ -6,8 +6,8 @@ export const apiConf = {
         validationRules: '/validationRules',
         outlierDetection: '/outlierDetection',
         followupAnalysis: '/dataAnalysis/followup',
-        markOutlierDataValue: '/dataValues/followup',
-        markFollowUpDataValue: '/dataAnalysis/followup/mark',
+        markFollowups: '/dataValues/followups',
+        markOutlier: '/dataValues/followup',
         reportAnalysis: '/dataAnalysis/report',
     },
     results: {

--- a/src/server.conf.js
+++ b/src/server.conf.js
@@ -5,7 +5,7 @@ export const apiConf = {
         validationRulesReport: '/dataAnalysis/validationRules/report',
         validationRules: '/validationRules',
         outlierDetection: '/outlierDetection',
-        folloupAnalysis: '/dataAnalysis/followup',
+        followupAnalysis: '/dataAnalysis/followup',
         markOutlierDataValue: '/dataValues/followup',
         markFollowUpDataValue: '/dataAnalysis/followup/mark',
         reportAnalysis: '/dataAnalysis/report',


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-11062

Use new UUID-based followups APIs introduced by https://github.com/dhis2/dhis2-core/pull/7906 (+ https://github.com/dhis2/dhis2-core/pull/7974) and https://github.com/dhis2/dhis2-core/pull/7943.

TODO:
- Add `periodDisplayName` to API response (https://jira.dhis2.org/browse/DHIS2-11446)