### PR TITLE
fix: add missing column styles to grid.css

### DIFF
--- a/src/grid.css
+++ b/src/grid.css
@@ -8,8 +8,20 @@
     padding: 0.5em;
 }
 
-.col-sm-12 {
+.col-xs-12, .col-sm-12 {
     width: 100%;
+}
+
+.col-xs-3 {
+    width: 25%;
+}
+
+.col-xs-9 {
+    width: 75%;
+}
+
+.col-xs-10 {
+    width: 83.333%;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11269

The validation details modal (accessible from the Validation Rule Analysis page) is not being rendered correctly as a result of missing classes from `grid.css`.

| Before | After |
----|----
|![image](https://user-images.githubusercontent.com/4295266/120665317-91c07080-c483-11eb-9c22-a9daf79bd4e7.png)|![image](https://user-images.githubusercontent.com/4295266/120665658-e2d06480-c483-11eb-9814-4b96320935cb.png)|
