### PR TITLE
fix: when react-router-dom is used as a hash router, we must prefix the href of internal links with '#'

### DIFF
--- a/src/components/Sidebar/SidebarItem.js
+++ b/src/components/Sidebar/SidebarItem.js
@@ -8,12 +8,17 @@ const SidebarItem = ({ label, path }) => {
     const history = useHistory()
     const isActive = !!useRouteMatch(path)
     const navigateToPath = () => history.push(path)
+    const href = history.createHref({
+        pathname: path,
+        search: '',
+        hash: '',
+    })
 
     return (
         <MenuItem
             className={styles.sidebarItem}
             onClick={navigateToPath}
-            href={path}
+            href={href}
             active={isActive}
             label={label}
         />


### PR DESCRIPTION
Our apps (including the data quality app) currently use react-router-dom as a hash router and hence internal app links must use a `href` that begins with `<app location>/#/`. Using `history.createHref` enables us to generate correct `href`s based on absolute paths (e.g. `/some-path`).