### PR TITLE
fix: load i18n from src/locales/index.js instead of d2-i18n in sections.conf.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,8 @@
+// Due to the way translations are handled in src/pages/sections.conf.js,
+// src/locales/index.js must be the first import in this file
+import './locales'
+import './grid.css'
+
 import { CssVariables } from '@dhis2/ui'
 import { MuiThemeProvider } from 'material-ui/styles'
 import React from 'react'
@@ -5,8 +10,6 @@ import { HashRouter } from 'react-router-dom'
 import 'material-design-icons-iconfont'
 import App from './components/App/App'
 import appTheme from './theme'
-import './grid.css'
-import './locales'
 
 const AppWrapper = () => (
     <>


### PR DESCRIPTION
Translations are not loaded until `src/App.js` loads `src/locales/index.js`, which results in the keys in `sections.conf.js` not being translated.

This PR fixes this issue by also loading `src/locales/index.js` in `sections.conf.js`.