### PR TITLE
fix: disable button if start date is after end date

### DIFF
--- a/src/pages/FollowUpAnalysis/FollowUpAnalysis.js
+++ b/src/pages/FollowUpAnalysis/FollowUpAnalysis.js
@@ -136,7 +136,8 @@ const FollowUpAnalysis = ({ sectionKey }) => {
         startDate &&
         endDate &&
         organisationUnitId &&
-        dataSetIds.length > 0
+        dataSetIds.length > 0 &&
+        startDate < endDate
     )
     const shouldShowMaxResultsAlertBar =
         tableVisible && elements.length >= apiConf.results.analysis.limit

--- a/src/pages/OutlierDetection/OutlierDetection.js
+++ b/src/pages/OutlierDetection/OutlierDetection.js
@@ -163,7 +163,8 @@ const OutlierDetection = () => {
         endDate &&
         organisationUnitIds.length > 0 &&
         threshold &&
-        dataSetIds.length > 0
+        dataSetIds.length > 0 &&
+        startDate < endDate
     )
     const shouldShowMaxResultsAlertBar =
         tableVisible && elements.length >= apiConf.results.analysis.limit

--- a/src/pages/ValidationRulesAnalysis/ValidationRulesAnalysis.js
+++ b/src/pages/ValidationRulesAnalysis/ValidationRulesAnalysis.js
@@ -87,7 +87,12 @@ const ValidationRulesAnalysis = ({ sectionKey }) => {
         }
         validate(params)
     }
-    const formValid = !!(startDate && endDate && organisationUnitId)
+    const formValid = !!(
+        startDate &&
+        endDate &&
+        organisationUnitId &&
+        startDate < endDate
+    )
     const shouldShowMaxResultsAlertBar =
         tableVisible && elements.length >= apiConf.results.analysis.limit
 


### PR DESCRIPTION
This PR disables the form button when start date is after the end date.

fixes [BETA-28](https://dhis2.atlassian.net/browse/BETA-28)

Screenshot
--

![followup-analysis](https://user-images.githubusercontent.com/1014725/233416068-cab2e48b-b3d6-46fa-9d38-c6c72bdfe7fc.gif)


[BETA-28]: https://dhis2.atlassian.net/browse/BETA-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ