### PR TITLE
chore: bump version to v99.9.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-quality-app",
-    "version": "2.0.0",
+    "version": "99.9.9",
     "description": "",
     "license": "BSD-3-Clause",
     "private": true,


### PR DESCRIPTION
bump version to 99.9.9 before trigger release